### PR TITLE
组件消息对象重命名

### DIFF
--- a/.changelog/v3.0.0.0.preview.3.0.md
+++ b/.changelog/v3.0.0.0.preview.3.0.md
@@ -116,6 +116,26 @@ final CardMessage message = builder.build();
 ]
 ```
 
+## 组件消息重命名 
+⚠️ 不兼容变更
+
+如上个版本中的预告所说，本次更新重命名所有组件下没有以 `Kaiheila` 开头的消息，使他们以 `Kaiheila` 开头。
+
+具体变更情况(包路径不变: `love.forte.simbot.component.kaiheila.message.*`)：
+- `AssetMessage` -> `KaiheilaAssetMessage`
+- `SimpleAssetMessage` -> `KaiheilaSimpleAssetMessage`
+- `AssetImage` -> `KaiheilaAssetImage`
+- `CardMessage` -> `KaiheilaCardMessage`
+- `AttachmentMessage` -> `KaiheilaAttachmentMessage`
+- `AtAllHere` -> `KaiheilaAtAllHere`
+- `KMarkdownMessage` -> `KaiheilaKMarkdownMessage`
+- `RequestMessage` -> `KaiheilaRequestMessage`
+- `` -> ``
+- `` -> ``
+- `` -> ``
+
+
+
 
 
 ## 更新日志

--- a/.changelog/v3.0.0.0.preview.3.0.md
+++ b/.changelog/v3.0.0.0.preview.3.0.md
@@ -121,19 +121,18 @@ final CardMessage message = builder.build();
 
 如上个版本中的预告所说，本次更新重命名所有组件下没有以 `Kaiheila` 开头的消息，使他们以 `Kaiheila` 开头。
 
-具体变更情况(包路径不变: `love.forte.simbot.component.kaiheila.message.*`)：
-- `AssetMessage` -> `KaiheilaAssetMessage`
-- `SimpleAssetMessage` -> `KaiheilaSimpleAssetMessage`
-- `AssetImage` -> `KaiheilaAssetImage`
-- `CardMessage` -> `KaiheilaCardMessage`
-- `AttachmentMessage` -> `KaiheilaAttachmentMessage`
-- `AtAllHere` -> `KaiheilaAtAllHere`
-- `KMarkdownMessage` -> `KaiheilaKMarkdownMessage`
-- `RequestMessage` -> `KaiheilaRequestMessage`
-- `` -> ``
-- `` -> ``
-- `` -> ``
+具体变更情况(包路径不变: `love.forte.simbot.component.kaiheila.message.*`)
 
+| 变更前                  | 变更后                          |
+|----------------------|------------------------------|
+| `AssetMessage`       | `KaiheilaAssetMessage`       |
+| `SimpleAssetMessage` | `KaiheilaSimpleAssetMessage` |
+| `AssetImage`         | `KaiheilaAssetImage`         |
+| `CardMessage`        | `KaiheilaCardMessage`        |
+| `AttachmentMessage`  | `KaiheilaAttachmentMessage`  |
+| `AtAllHere`          | `KaiheilaAtAllHere`          |
+| `KMarkdownMessage`   | `KaiheilaKMarkdownMessage`   |
+| `RequestMessage`     | `KaiheilaRequestMessage`     |
 
 
 

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/KaiheilaComponent.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/KaiheilaComponent.kt
@@ -71,12 +71,12 @@ public class KaiheilaComponent : Component {
         @OptIn(ExperimentalSimbotApi::class)
         public val messageSerializersModule: SerializersModule = SerializersModule {
             fun PolymorphicModuleBuilder<KaiheilaMessageElement<*>>.include() {
-                subclass(SimpleAssetMessage::class, SimpleAssetMessage.serializer())
-                subclass(AssetImage::class, AssetImage.serializer())
-                subclass(AtAllHere::class, AtAllHere.serializer())
-                subclass(AttachmentMessage::class, AttachmentMessage.serializer())
-                subclass(CardMessage::class, CardMessage.serializer())
-                subclass(KMarkdownMessage::class, KMarkdownMessage.serializer())
+                subclass(KaiheilaSimpleAssetMessage::class, KaiheilaSimpleAssetMessage.serializer())
+                subclass(KaiheilaAssetImage::class, KaiheilaAssetImage.serializer())
+                subclass(KaiheilaAtAllHere::class, KaiheilaAtAllHere.serializer())
+                subclass(KaiheilaAttachmentMessage::class, KaiheilaAttachmentMessage.serializer())
+                subclass(KaiheilaCardMessage::class, KaiheilaCardMessage.serializer())
+                subclass(KaiheilaKMarkdownMessage::class, KaiheilaKMarkdownMessage.serializer())
             }
             polymorphic(KMarkdown::class) {
                 subclass(RawValueKMarkdown::class, RawValueKMarkdown.serializer())

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/KaiheilaComponentBot.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/KaiheilaComponentBot.kt
@@ -20,9 +20,9 @@ package love.forte.simbot.component.kaiheila
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import love.forte.simbot.*
-import love.forte.simbot.component.kaiheila.message.AssetImage
-import love.forte.simbot.component.kaiheila.message.AssetMessage
-import love.forte.simbot.component.kaiheila.message.SimpleAssetMessage
+import love.forte.simbot.component.kaiheila.message.KaiheilaAssetImage
+import love.forte.simbot.component.kaiheila.message.KaiheilaAssetMessage
+import love.forte.simbot.component.kaiheila.message.KaiheilaSimpleAssetMessage
 import love.forte.simbot.definition.Group
 import love.forte.simbot.definition.UserStatus
 import love.forte.simbot.event.EventProcessor
@@ -98,34 +98,34 @@ public abstract class KaiheilaComponentBot : Bot {
 
     //region image api
     /**
-     * 上传一个资源并得到一个 [AssetMessage].
+     * 上传一个资源并得到一个 [KaiheilaAssetMessage].
      *
      * @param resource 需要上传的资源
      * @param type 在发送时所需要使用的消息类型。通常选择为 [MessageType.IMAGE]、[MessageType.FILE] 中的值，即 `2`、`3`、`4`。
      */
     @JvmSynthetic
-    public abstract suspend fun uploadAsset(resource: Resource, type: Int): SimpleAssetMessage
+    public abstract suspend fun uploadAsset(resource: Resource, type: Int): KaiheilaSimpleAssetMessage
 
     /**
-     * 上传一个资源并得到一个 [AssetMessage].
+     * 上传一个资源并得到一个 [KaiheilaAssetMessage].
      * @param resource 需要上传的资源
      * @param type 在发送时所需要使用的消息类型。通常选择为 [MessageType.IMAGE]、[MessageType.FILE] 中的值.
      */
     @JvmSynthetic
-    public suspend fun uploadAsset(resource: Resource, type: MessageType): SimpleAssetMessage = uploadAsset(resource, type.type)
+    public suspend fun uploadAsset(resource: Resource, type: MessageType): KaiheilaSimpleAssetMessage = uploadAsset(resource, type.type)
 
 
     /**
-     * 提供一个资源类型并将其上传后作为 [AssetImage] 使用。
+     * 提供一个资源类型并将其上传后作为 [KaiheilaAssetImage] 使用。
      */
     @JvmSynthetic
-    abstract override suspend fun uploadImage(resource: Resource): AssetImage
+    abstract override suspend fun uploadImage(resource: Resource): KaiheilaAssetImage
 
     /**
-     * 提供一个资源类型并将其上传后作为 [AssetImage] 使用。
+     * 提供一个资源类型并将其上传后作为 [KaiheilaAssetImage] 使用。
      */
     @Api4J
-    override fun uploadImageBlocking(resource: Resource): AssetImage = runInBlocking { uploadImage(resource) }
+    override fun uploadImageBlocking(resource: Resource): KaiheilaAssetImage = runInBlocking { uploadImage(resource) }
 
     /**
      * 由于开黑啦中的资源不存在id，因此会直接将 [id] 视为 url 进行转化。
@@ -134,10 +134,10 @@ public abstract class KaiheilaComponentBot : Bot {
      *
      */
     @JvmSynthetic
-    abstract override suspend fun resolveImage(id: ID): AssetImage
+    abstract override suspend fun resolveImage(id: ID): KaiheilaAssetImage
 
     @OptIn(Api4J::class)
-    override fun resolveImageBlocking(id: ID): AssetImage = runInBlocking { resolveImage(id) }
+    override fun resolveImageBlocking(id: ID): KaiheilaAssetImage = runInBlocking { resolveImage(id) }
     //endregion
 
     @OptIn(ExperimentalSimbotApi::class)

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/event/KaiheilaChannelChangedEvent.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/event/KaiheilaChannelChangedEvent.kt
@@ -23,7 +23,7 @@ import love.forte.simbot.Timestamp
 import love.forte.simbot.component.kaiheila.KaiheilaChannel
 import love.forte.simbot.component.kaiheila.KaiheilaGuild
 import love.forte.simbot.component.kaiheila.KaiheilaGuildMember
-import love.forte.simbot.component.kaiheila.message.toContent
+import love.forte.simbot.component.kaiheila.message.KaiheilaChannelMessageDetailsContent.Companion.toContent
 import love.forte.simbot.component.kaiheila.util.requestDataBy
 import love.forte.simbot.definition.ChannelInfoContainer
 import love.forte.simbot.event.*

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/internal/KaiheilaComponentBotImpl.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/internal/KaiheilaComponentBotImpl.kt
@@ -28,11 +28,11 @@ import love.forte.simbot.component.kaiheila.KaiheilaComponentBot
 import love.forte.simbot.component.kaiheila.KaiheilaComponentBotConfiguration
 import love.forte.simbot.component.kaiheila.event.KaiheilaBotStartedEvent
 import love.forte.simbot.component.kaiheila.internal.event.KaiheilaBotStartedEventImpl
-import love.forte.simbot.component.kaiheila.message.AssetImage
-import love.forte.simbot.component.kaiheila.message.AssetMessage
-import love.forte.simbot.component.kaiheila.message.AssetMessage.Key.asImage
-import love.forte.simbot.component.kaiheila.message.AssetMessage.Key.asMessage
-import love.forte.simbot.component.kaiheila.message.SimpleAssetMessage
+import love.forte.simbot.component.kaiheila.message.KaiheilaAssetImage
+import love.forte.simbot.component.kaiheila.message.KaiheilaAssetMessage
+import love.forte.simbot.component.kaiheila.message.KaiheilaAssetMessage.Key.asImage
+import love.forte.simbot.component.kaiheila.message.KaiheilaAssetMessage.Key.asMessage
+import love.forte.simbot.component.kaiheila.message.KaiheilaSimpleAssetMessage
 import love.forte.simbot.component.kaiheila.util.requestDataBy
 import love.forte.simbot.definition.UserStatus
 import love.forte.simbot.event.EventProcessor
@@ -309,14 +309,14 @@ internal class KaiheilaComponentBotImpl(
     //region image api / assert api
 
     /**
-     * 上传一个资源并得到一个 [AssetMessage].
+     * 上传一个资源并得到一个 [KaiheilaAssetMessage].
      *
      * @param resource 需要上传的资源
      * @param type 在发送时所需要使用的消息类型。通常选择为 [MessageType.IMAGE]、[MessageType.FILE] 中的值，
      * 即 `2`、`3`、`4`。
      */
     @JvmSynthetic
-    override suspend fun uploadAsset(resource: Resource, type: Int): SimpleAssetMessage {
+    override suspend fun uploadAsset(resource: Resource, type: Int): KaiheilaSimpleAssetMessage {
         val asset = AssetCreateRequest(resource).requestDataBy(this)
         return asset.asMessage(type)
     }
@@ -327,14 +327,14 @@ internal class KaiheilaComponentBotImpl(
      */
     @OptIn(ApiResultType::class)
     @JvmSynthetic
-    override suspend fun resolveImage(id: ID): AssetImage {
+    override suspend fun resolveImage(id: ID): KaiheilaAssetImage {
         Simbot.require(id.literal.startsWith(ASSET_PREFIX)) {
             "The id must be the resource id of the kaiheila and must start with $ASSET_PREFIX"
         }
-        return AssetImage(AssetCreated(id.literal))
+        return KaiheilaAssetImage(AssetCreated(id.literal))
     }
 
-    override suspend fun uploadImage(resource: Resource): AssetImage {
+    override suspend fun uploadImage(resource: Resource): KaiheilaAssetImage {
         val asset = AssetCreateRequest(resource).requestDataBy(this)
         return asset.asImage()
     }

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaAssetMessage.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaAssetMessage.kt
@@ -33,12 +33,12 @@ import love.forte.simbot.resources.URLResource
 /**
  * 与上传后的媒体资源相关的消息类型。
  *
- * @see SimpleAssetMessage
- * @see AssetImage
+ * @see KaiheilaSimpleAssetMessage
+ * @see KaiheilaAssetImage
  *
  */
 @Serializable
-public sealed class AssetMessage<M : AssetMessage<M>> : KaiheilaMessageElement<M> {
+public sealed class KaiheilaAssetMessage<M : KaiheilaAssetMessage<M>> : KaiheilaMessageElement<M> {
     abstract override val key: Message.Key<M>
 
     /**
@@ -54,30 +54,30 @@ public sealed class AssetMessage<M : AssetMessage<M>> : KaiheilaMessageElement<M
      */
     public abstract val type: Int
 
-    public companion object Key : Message.Key<AssetMessage<*>> {
-        override fun safeCast(value: Any): AssetMessage<*>? = doSafeCast(value)
+    public companion object Key : Message.Key<KaiheilaAssetMessage<*>> {
+        override fun safeCast(value: Any): KaiheilaAssetMessage<*>? = doSafeCast(value)
 
 
         /**
-         * 使用当前的 [AssetCreated] 构建一个 [AssetMessage] 实例。
+         * 使用当前的 [AssetCreated] 构建一个 [KaiheilaAssetMessage] 实例。
          * @param type 在发送时所需要使用的消息类型。通常选择为 [MessageType.IMAGE]、[MessageType.FILE]、[MessageType.VIDEO] 中的值，即 `2`、`3`、`4`。
          */
         @JvmStatic
-        public fun AssetCreated.asMessage(type: Int): SimpleAssetMessage = SimpleAssetMessage(this, type)
+        public fun AssetCreated.asMessage(type: Int): KaiheilaSimpleAssetMessage = KaiheilaSimpleAssetMessage(this, type)
 
         /**
-         * 使用当前的 [AssetCreated] 构建一个 [AssetMessage] 实例。
+         * 使用当前的 [AssetCreated] 构建一个 [KaiheilaAssetMessage] 实例。
          * @param type 在发送时所需要使用的消息类型。通常选择为 [MessageType.IMAGE]、[MessageType.FILE]、[MessageType.VIDEO] 中的值。
          */
         @JvmStatic
-        public fun AssetCreated.asMessage(type: MessageType): SimpleAssetMessage = SimpleAssetMessage(this, type)
+        public fun AssetCreated.asMessage(type: MessageType): KaiheilaSimpleAssetMessage = KaiheilaSimpleAssetMessage(this, type)
 
 
         /**
-         * 使用当前的 [AssetCreated] 构建一个 [AssetImage] 实例。
+         * 使用当前的 [AssetCreated] 构建一个 [KaiheilaAssetImage] 实例。
          */
         @JvmStatic
-        public fun AssetCreated.asImage(): AssetImage = AssetImage(this)
+        public fun AssetCreated.asImage(): KaiheilaAssetImage = KaiheilaAssetImage(this)
     }
 }
 
@@ -90,7 +90,7 @@ public sealed class AssetMessage<M : AssetMessage<M>> : KaiheilaMessageElement<M
  */
 @SerialName("khl.asset.std")
 @Serializable
-public data class SimpleAssetMessage(
+public data class KaiheilaSimpleAssetMessage(
     /**
      * 创建的文件资源。
      */
@@ -104,14 +104,14 @@ public data class SimpleAssetMessage(
      */
     @SerialName("assetType")
     override val type: Int
-) : AssetMessage<SimpleAssetMessage>() {
+) : KaiheilaAssetMessage<KaiheilaSimpleAssetMessage>() {
     public constructor(asset: AssetCreated, type: MessageType) : this(asset, type.type)
 
-    override val key: Message.Key<SimpleAssetMessage>
+    override val key: Message.Key<KaiheilaSimpleAssetMessage>
         get() = Key
 
-    public companion object Key : Message.Key<SimpleAssetMessage> {
-        override fun safeCast(value: Any): SimpleAssetMessage? = doSafeCast(value)
+    public companion object Key : Message.Key<KaiheilaSimpleAssetMessage> {
+        override fun safeCast(value: Any): KaiheilaSimpleAssetMessage? = doSafeCast(value)
     }
 }
 
@@ -121,7 +121,7 @@ public data class SimpleAssetMessage(
  */
 @SerialName("khl.asset.img")
 @Serializable
-public data class AssetImage(override val asset: AssetCreated) : AssetMessage<AssetImage>(), Image<AssetImage> {
+public data class KaiheilaAssetImage(override val asset: AssetCreated) : KaiheilaAssetMessage<KaiheilaAssetImage>(), Image<KaiheilaAssetImage> {
     override val type: Int
         get() = MessageType.IMAGE.type
 
@@ -133,11 +133,11 @@ public data class AssetImage(override val asset: AssetCreated) : AssetMessage<As
     @JvmSynthetic
     override suspend fun resource(): Resource = resource
 
-    override val key: Message.Key<AssetImage>
+    override val key: Message.Key<KaiheilaAssetImage>
         get() = Key
 
-    public companion object Key : Message.Key<AssetImage> {
-        override fun safeCast(value: Any): AssetImage? = doSafeCast(value)
+    public companion object Key : Message.Key<KaiheilaAssetImage> {
+        override fun safeCast(value: Any): KaiheilaAssetImage? = doSafeCast(value)
     }
 
 }

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaAtAllHere.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaAtAllHere.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
  *
  *  本文件是 simbot-component-kaiheila 的一部分。
  *
@@ -19,32 +19,32 @@ package love.forte.simbot.component.kaiheila.message
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import love.forte.simbot.kaiheila.objects.Attachments
+import love.forte.simbot.message.At
+import love.forte.simbot.message.AtAll
 import love.forte.simbot.message.Message
-import love.forte.simbot.message.doSafeCast
 
 
 /**
  *
- * 将 [Attachments] 作为消息对象。
+ * 通知(mention)所有当前的 **在线用户**。
  *
- * 通常在接收时使用。
+ * 行为与概念与 [AtAll] 类似。
  *
- * @author ForteScarlet
+ * **注意，目前来看，发消息bot无法at他人，
+ * 因此目前此参数只能来自于事件，发送时会被忽略。
+ * 此情况也适用于 [At] 和 [AtAll]。**
+ *
  */
-@SerialName("khl.attachment")
+@SerialName("khl.AtAllHere")
 @Serializable
-public data class AttachmentMessage(public val attachment: Attachments) : KaiheilaMessageElement<AttachmentMessage> {
+public object KaiheilaAtAllHere : KaiheilaMessageElement<KaiheilaAtAllHere>, Message.Key<KaiheilaAtAllHere> {
+    override val key: Message.Key<KaiheilaAtAllHere>
+        get() = this
 
-    override val key: Message.Key<AttachmentMessage>
-        get() = Key
+    override fun equals(other: Any?): Boolean = other === this
 
-    public companion object Key : Message.Key<AttachmentMessage> {
-        override fun safeCast(value: Any): AttachmentMessage? = doSafeCast(value)
-    }
+    override fun toString(): String = "AtAllHere"
+
+    override fun safeCast(value: Any): KaiheilaAtAllHere? = if (value === this) this else null
+
 }
-
-/**
- * 将 [Attachments] 转化为 [AttachmentMessage]。
- */
-public fun Attachments.asMessage(): AttachmentMessage = AttachmentMessage(this)

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaAttachmentMessage.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaAttachmentMessage.kt
@@ -19,30 +19,35 @@ package love.forte.simbot.component.kaiheila.message
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import love.forte.simbot.ExperimentalSimbotApi
-import love.forte.simbot.kaiheila.objects.KMarkdown
+import love.forte.simbot.kaiheila.objects.Attachments
 import love.forte.simbot.message.Message
 import love.forte.simbot.message.doSafeCast
 
 
 /**
- * 将 [KMarkdown] 作为消息使用。
+ *
+ * 将 [Attachments] 作为消息对象。
+ *
+ * 通常在接收时使用。
+ *
  * @author ForteScarlet
  */
-@SerialName("khl.kmd")
+@SerialName("khl.attachment")
 @Serializable
-@OptIn(ExperimentalSimbotApi::class)
-public data class KMarkdownMessage(public val kMarkdown: KMarkdown) : KaiheilaMessageElement<KMarkdownMessage> {
-    override val key: Message.Key<KMarkdownMessage>
+public data class KaiheilaAttachmentMessage(public val attachment: Attachments) : KaiheilaMessageElement<KaiheilaAttachmentMessage> {
+
+    override val key: Message.Key<KaiheilaAttachmentMessage>
         get() = Key
 
-    public companion object Key : Message.Key<KMarkdownMessage> {
-        override fun safeCast(value: Any): KMarkdownMessage? = doSafeCast(value)
+    public companion object Key : Message.Key<KaiheilaAttachmentMessage> {
+        override fun safeCast(value: Any): KaiheilaAttachmentMessage? = doSafeCast(value)
+
+
+        /**
+         * 将 [Attachments] 转化为 [KaiheilaAttachmentMessage]。
+         */
+        @JvmStatic
+        public fun Attachments.asMessage(): KaiheilaAttachmentMessage = KaiheilaAttachmentMessage(this)
+
     }
 }
-
-/**
- * 将 [KMarkdown] 作为 [KMarkdownMessage] 使用。
- */
-@OptIn(ExperimentalSimbotApi::class)
-public fun KMarkdown.asMessage(): KMarkdownMessage = KMarkdownMessage(this)

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaCardMessage.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaCardMessage.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
  *
  *  本文件是 simbot-component-kaiheila 的一部分。
  *
@@ -33,17 +33,19 @@ import love.forte.simbot.kaiheila.objects.CardMessage as KhlCardMessage
 @ExperimentalSimbotApi
 @SerialName("khl.card")
 @Serializable
-public data class CardMessage(public val cards: KhlCardMessage) : KaiheilaMessageElement<CardMessage> {
-    override val key: Message.Key<CardMessage>
+public data class KaiheilaCardMessage(public val cards: KhlCardMessage) : KaiheilaMessageElement<KaiheilaCardMessage> {
+    override val key: Message.Key<KaiheilaCardMessage>
         get() = Key
 
-    public companion object Key : Message.Key<CardMessage> {
-        override fun safeCast(value: Any): CardMessage? = doSafeCast(value)
+    public companion object Key : Message.Key<KaiheilaCardMessage> {
+        override fun safeCast(value: Any): KaiheilaCardMessage? = doSafeCast(value)
+
+
+        /**
+         * 将 [Card] 作为 [KaiheilaCardMessage] 使用。
+         */
+        @JvmStatic
+        @ExperimentalSimbotApi
+        public fun KhlCardMessage.asMessage(): KaiheilaCardMessage = KaiheilaCardMessage(this)
     }
 }
-
-/**
- * 将 [Card] 作为 [CardMessage] 使用。
- */
-@ExperimentalSimbotApi
-public fun KhlCardMessage.asMessage(): CardMessage = CardMessage(this)

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaChannelMessageDetailsContent.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaChannelMessageDetailsContent.kt
@@ -44,15 +44,23 @@ public data class KaiheilaChannelMessageDetailsContent(internal val details: Cha
      */
     override val messages: Messages = details.toMessages()
 
+    public companion object {
+        /**
+         * 使用消息事件并将其中的消息内容转化为 [Messages].
+         */
+        @JvmStatic
+        public fun ChannelMessageDetails.toMessages(): Messages {
+            return toMessages(content.toText(), mention, mentionRoles, isMentionAll, isMentionHere)
+        }
+
+        /**
+         * 使用消息事件并将其中的消息内容转化为 [KaiheilaChannelMessageDetailsContent].
+         */
+        @JvmStatic
+        public fun ChannelMessageDetails.toContent(): KaiheilaChannelMessageDetailsContent =
+            KaiheilaChannelMessageDetailsContent(this)
+
+    }
 
 }
 
-public fun ChannelMessageDetails.toMessages(): Messages {
-    return toMessages(content.toText(), mention, mentionRoles, isMentionAll, isMentionHere)
-}
-
-/**
- * 使用消息事件并将其中的消息内容转化为 [KaiheilaChannelMessageDetailsContent].
- */
-public fun ChannelMessageDetails.toContent(): KaiheilaChannelMessageDetailsContent =
-    KaiheilaChannelMessageDetailsContent(this)

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaKMarkdownMessage.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaKMarkdownMessage.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 ForteScarlet <ForteScarlet@163.com>
+ *  Copyright (c) 2022-2022 ForteScarlet <ForteScarlet@163.com>
  *
  *  本文件是 simbot-component-kaiheila 的一部分。
  *
@@ -19,39 +19,33 @@ package love.forte.simbot.component.kaiheila.message
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import love.forte.simbot.message.At
-import love.forte.simbot.message.AtAll
+import love.forte.simbot.ExperimentalSimbotApi
+import love.forte.simbot.kaiheila.objects.KMarkdown
 import love.forte.simbot.message.Message
+import love.forte.simbot.message.doSafeCast
 
 
 /**
- *
- * 通知(mention)所有当前的 **在线用户**。
- *
- * 行为与概念与 [AtAll] 类似。
- *
- * **注意，目前来看，发消息bot无法at他人，
- * 因此目前此参数只能来自于事件，发送时会被忽略。
- * 此情况也适用于 [At] 和 [AtAll]。**
- *
+ * 将 [KMarkdown] 作为消息使用。
+ * @author ForteScarlet
  */
-@SerialName("khl.AtAllHere")
+@SerialName("khl.kmd")
 @Serializable
-public object AtAllHere : KaiheilaMessageElement<AtAllHere>, Message.Key<AtAllHere> {
-    override val key: Message.Key<AtAllHere>
-        get() = this
+@OptIn(ExperimentalSimbotApi::class)
+public data class KaiheilaKMarkdownMessage(public val kMarkdown: KMarkdown) : KaiheilaMessageElement<KaiheilaKMarkdownMessage> {
+    override val key: Message.Key<KaiheilaKMarkdownMessage>
+        get() = Key
 
-    override fun equals(other: Any?): Boolean = other === this
+    public companion object Key : Message.Key<KaiheilaKMarkdownMessage> {
+        override fun safeCast(value: Any): KaiheilaKMarkdownMessage? = doSafeCast(value)
 
-    override fun toString(): String = "AtAllHere"
 
-    override fun safeCast(value: Any): AtAllHere? = if (value === this) this else null
+        /**
+         * 将 [KMarkdown] 作为 [KaiheilaKMarkdownMessage] 使用。
+         */
+        @JvmStatic
+        public fun KMarkdown.asMessage(): KaiheilaKMarkdownMessage = KaiheilaKMarkdownMessage(this)
 
+    }
 }
 
-
-
-/**
- * @see AtAllHere
- */
-public typealias MentionAllHere = AtAllHere

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaMessageCreatedReceipt.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaMessageCreatedReceipt.kt
@@ -74,7 +74,7 @@ public class KaiheilaMessageCreatedReceipt(
  *
  * 与 [KaiheilaMessageCreatedReceipt] 不同的是，
  * [KaiheilaApiRequestedReceipt] 很可能并不是通过执行的消息api，
- * 例如通过 [RequestMessage] 执行了一个任意的请求。
+ * 例如通过 [KaiheilaRequestMessage] 执行了一个任意的请求。
  *
  * 也正因此，此回执不支持 [删除][DeleteSupport] 操作。
  *

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaMessageElement.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaMessageElement.kt
@@ -37,10 +37,10 @@ public annotation class SendOnlyMessage
  * ## SendOnlyMessage
  * 对于一些**仅用于发送**的消息，它们会被标记上 [SendOnlyMessage] 注解，并大概率无法支持序列化。
  *
- * @see AssetMessage
- * @see AtAllHere
- * @see CardMessage
- * @see KMarkdownMessage
+ * @see KaiheilaAssetMessage
+ * @see KaiheilaAtAllHere
+ * @see KaiheilaCardMessage
+ * @see KaiheilaKMarkdownMessage
  *
  * @author ForteScarlet
  */

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaMessages.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaMessages.kt
@@ -156,16 +156,16 @@ private fun Message.Element<*>.elementToRequestOrNull(
 
         is KaiheilaMessageElement<*> -> when (this) {
             // 媒体资源
-            is AssetMessage<*> -> request(type, asset.url)
+            is KaiheilaAssetMessage<*> -> request(type, asset.url)
             // KMarkdown
-            is KMarkdownMessage -> request(MessageType.KMARKDOWN.type, kMarkdown.rawContent)
+            is KaiheilaKMarkdownMessage -> request(MessageType.KMARKDOWN.type, kMarkdown.rawContent)
             // card message
-            is CardMessage -> request(MessageType.CARD.type, cards.decode())
+            is KaiheilaCardMessage -> request(MessageType.CARD.type, cards.decode())
 
             // request message
-            is RequestMessage -> this.request
+            is KaiheilaRequestMessage -> this.request
 
-            is AtAllHere -> {
+            is KaiheilaAtAllHere -> {
                 val content = buildRawKMarkdown {
                     at(AtTarget.Here)
                 }
@@ -173,7 +173,7 @@ private fun Message.Element<*>.elementToRequestOrNull(
                 request(MessageType.KMARKDOWN.type, content)
             }
 
-            is AttachmentMessage -> {
+            is KaiheilaAttachmentMessage -> {
                 // TODO
                 // buildRawKMarkdown {
                 //

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaReceiveMessageContent.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaReceiveMessageContent.kt
@@ -19,6 +19,8 @@ package love.forte.simbot.component.kaiheila.message
 
 import love.forte.simbot.ExperimentalSimbotApi
 import love.forte.simbot.ID
+import love.forte.simbot.component.kaiheila.message.KaiheilaAttachmentMessage.Key.asMessage
+import love.forte.simbot.component.kaiheila.message.KaiheilaKMarkdownMessage.Key.asMessage
 import love.forte.simbot.component.kaiheila.message.KaiheilaMessages.AT_TYPE_ROLE
 import love.forte.simbot.component.kaiheila.message.KaiheilaMessages.AT_TYPE_USER
 import love.forte.simbot.kaiheila.event.Event
@@ -111,7 +113,7 @@ internal fun toMessages(
         }
 
         if (isMentionHere) {
-            add(AtAllHere)
+            add(KaiheilaAtAllHere)
         }
 
         for (mentionId in mention) {

--- a/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaRequestMessage.kt
+++ b/simbot-component-kaiheila-core/src/main/kotlin/love/forte/simbot/component/kaiheila/message/KaiheilaRequestMessage.kt
@@ -34,18 +34,21 @@ import love.forte.simbot.message.doSafeCast
  * @author ForteScarlet
  */
 @SendOnlyMessage
-public data class RequestMessage(public val request: KaiheilaApiRequest<*>) :
-    KaiheilaMessageElement<RequestMessage> {
+public data class KaiheilaRequestMessage(public val request: KaiheilaApiRequest<*>) :
+    KaiheilaMessageElement<KaiheilaRequestMessage> {
 
-    override val key: Message.Key<RequestMessage>
+    override val key: Message.Key<KaiheilaRequestMessage>
         get() = Key
 
-    public companion object Key : Message.Key<RequestMessage> {
-        override fun safeCast(value: Any): RequestMessage? = doSafeCast(value)
+    public companion object Key : Message.Key<KaiheilaRequestMessage> {
+        override fun safeCast(value: Any): KaiheilaRequestMessage? = doSafeCast(value)
+
+        /**
+         * 通过 [KaiheilaRequestMessage] 构建 [KaiheilaRequestMessage].
+         */
+        @JvmStatic
+        public fun KaiheilaApiRequest<*>.toRequest(): KaiheilaRequestMessage = KaiheilaRequestMessage(this)
+
     }
 }
 
-/**
- * 通过 [RequestMessage] 构建 [RequestMessage].
- */
-public fun KaiheilaApiRequest<*>.toRequest(): RequestMessage = RequestMessage(this)

--- a/simbot-component-kaiheila-core/src/test/kotlin/example/MessageSerializerTest.kt
+++ b/simbot-component-kaiheila-core/src/test/kotlin/example/MessageSerializerTest.kt
@@ -21,9 +21,9 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.plus
 import love.forte.simbot.ExperimentalSimbotApi
 import love.forte.simbot.component.kaiheila.KaiheilaComponent
-import love.forte.simbot.component.kaiheila.message.AssetImage
-import love.forte.simbot.component.kaiheila.message.AtAllHere
-import love.forte.simbot.component.kaiheila.message.KMarkdownMessage
+import love.forte.simbot.component.kaiheila.message.KaiheilaAssetImage
+import love.forte.simbot.component.kaiheila.message.KaiheilaAtAllHere
+import love.forte.simbot.component.kaiheila.message.KaiheilaKMarkdownMessage
 import love.forte.simbot.kaiheila.api.ApiResultType
 import love.forte.simbot.kaiheila.api.asset.AssetCreated
 import love.forte.simbot.kaiheila.objects.buildKMarkdown
@@ -41,12 +41,12 @@ class MessageSerializerTest {
     @Test
     fun encodeTest() {
         val messages = buildMessages {
-            +AtAllHere
-            +KMarkdownMessage(buildKMarkdown {
+            +KaiheilaAtAllHere
+            +KaiheilaKMarkdownMessage(buildKMarkdown {
                 at("1234")
                 link("Simbot Home", "http://simbot.forte.love")
             })
-            +AssetImage(AssetCreated("https://baidu.com"))
+            +KaiheilaAssetImage(AssetCreated("https://baidu.com"))
         }
 
         println(messages)


### PR DESCRIPTION
如上个版本中的预告所说，本次更新重命名所有组件下没有以 `Kaiheila` 开头的消息，使他们以 `Kaiheila` 开头。

具体变更情况(包路径不变: `love.forte.simbot.component.kaiheila.message.*`)

| 变更前                  | 变更后                          |
|----------------------|------------------------------|
| `AssetMessage`       | `KaiheilaAssetMessage`       |
| `SimpleAssetMessage` | `KaiheilaSimpleAssetMessage` |
| `AssetImage`         | `KaiheilaAssetImage`         |
| `CardMessage`        | `KaiheilaCardMessage`        |
| `AttachmentMessage`  | `KaiheilaAttachmentMessage`  |
| `AtAllHere`          | `KaiheilaAtAllHere`          |
| `KMarkdownMessage`   | `KaiheilaKMarkdownMessage`   |
| `RequestMessage`     | `KaiheilaRequestMessage`     |

